### PR TITLE
Make unchecked elements go up

### DIFF
--- a/base/src/main/java/com/maubis/scarlet/base/core/format/Format.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/core/format/Format.kt
@@ -80,5 +80,16 @@ fun sectionPreservingSort(formats: List<Format>): List<Format> {
     }
     index += 1
   }
+  while (index > 0) {
+    val currentItem = mutableFormats[index]
+    val nextItem = mutableFormats[index - 1]
+
+    if (currentItem.formatType == FormatType.CHECKLIST_UNCHECKED
+            && nextItem.formatType == FormatType.CHECKLIST_CHECKED) {
+      Collections.swap(mutableFormats, index, index - 1)
+      continue
+    }
+    index -= 1
+  }
   return mutableFormats
 }


### PR DESCRIPTION
This is a simple way of making elements go up when we uncheck them. 

I used a lot Scarlet to make list that I reuse items by checking and unchecking items and it annoys me a lot to move items up each times I unchecked it.