### PR TITLE
Fix minimum text holder height being based on hint text instead of actual text (#120)

### DIFF
--- a/base/src/main/java/com/maubis/scarlet/base/core/format/FormatType.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/core/format/FormatType.kt
@@ -13,5 +13,5 @@ enum class FormatType {
   CODE,
   QUOTE,
   SEPARATOR,
-  EMPTY,
+  EMPTY
 }

--- a/base/src/main/res/layout/item_format_code.xml
+++ b/base/src/main/res/layout/item_format_code.xml
@@ -7,7 +7,6 @@
   <TextView
     android:id="@+id/text"
     style="@style/FormatText"
-    android:hint="@string/format_hint_code"
     android:padding="@dimen/spacing_normal"
     android:fontFamily="monospace"
     android:textColor="@color/transparent"
@@ -16,7 +15,6 @@
   <EditText
     android:id="@+id/edit"
     style="@style/FormatText"
-    android:hint="@string/format_hint_code"
     android:padding="@dimen/spacing_normal"
     android:fontFamily="monospace"
     android:textColor="@color/transparent"

--- a/base/src/main/res/layout/item_format_heading.xml
+++ b/base/src/main/res/layout/item_format_heading.xml
@@ -8,13 +8,11 @@
     android:id="@+id/text"
     style="@style/FormatText"
     android:fontFamily="@font/monserrat"
-    android:hint="@string/format_hint_heading"
     android:textStyle="bold" />
 
   <EditText
     android:id="@+id/edit"
     style="@style/FormatEdit"
     android:fontFamily="@font/monserrat"
-    android:hint="@string/format_hint_heading"
     android:textStyle="bold" />
 </LinearLayout>

--- a/base/src/main/res/layout/item_format_list.xml
+++ b/base/src/main/res/layout/item_format_list.xml
@@ -17,11 +17,9 @@
     android:id="@+id/text"
     style="@style/FormatEdit"
     android:autoLink="web"
-    android:hint="@string/format_hint_list"
     android:linksClickable="true" />
 
   <EditText
     android:id="@+id/edit"
-    style="@style/FormatText"
-    android:hint="@string/format_hint_list" />
+    style="@style/FormatText" />
 </LinearLayout>

--- a/base/src/main/res/layout/item_format_quote.xml
+++ b/base/src/main/res/layout/item_format_quote.xml
@@ -17,7 +17,6 @@
     android:id="@+id/text"
     style="@style/FormatText"
     android:autoLink="web"
-    android:hint="@string/format_hint_quote"
     android:linksClickable="true"
     android:paddingStart="@dimen/spacing_xxsmall"
     android:paddingBottom="@dimen/spacing_small"
@@ -26,7 +25,6 @@
   <EditText
     android:id="@+id/edit"
     style="@style/FormatEdit"
-    android:hint="@string/format_hint_quote"
     android:textStyle="italic" />
 
 </LinearLayout>

--- a/base/src/main/res/layout/item_format_tag.xml
+++ b/base/src/main/res/layout/item_format_tag.xml
@@ -9,13 +9,11 @@
     android:id="@+id/text"
     style="@style/FormatText"
     android:autoLink="web"
-    android:hint="@string/format_hint_text"
     android:linksClickable="true" />
 
   <EditText
     android:id="@+id/edit"
     style="@style/FormatEdit"
-    android:hint="@string/format_hint_text"
     android:minLines="3"
     android:visibility="gone" />
 </LinearLayout>

--- a/base/src/main/res/layout/item_format_text.xml
+++ b/base/src/main/res/layout/item_format_text.xml
@@ -9,12 +9,10 @@
     android:id="@+id/text"
     style="@style/FormatText"
     android:autoLink="web"
-    android:hint="@string/format_hint_text"
     android:linksClickable="true" />
 
   <EditText
     android:id="@+id/edit"
     style="@style/FormatEdit"
-    android:hint="@string/format_hint_text"
     android:minLines="3" />
 </LinearLayout>


### PR DESCRIPTION
I've fixed #120 by removing useless hint texts for TextViews used in FormatTextViewHolder (since they're never displayed when their content is empty) and by removing the hint for the EditTexts programmatically when they are not empty anymore (obviously the hint is restored when the EditText becomes empty again).